### PR TITLE
invalid reference format fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/maksymbilenko/oracle-ee-12c-base:latest:latest
+FROM quay.io/maksymbilenko/oracle-ee-12c-base:latest
 
 ENV DBCA_TOTAL_MEMORY 4096
 ENV WEB_CONSOLE true


### PR DESCRIPTION
At building this output is shown:

`esturdolh@lpc:docker-oracle-ee-12c\✨ sudo docker build -t ora-ee-12c .
Sending build context to Docker daemon  156.7kB
Step 1/17 : FROM quay.io/maksymbilenko/oracle-ee-12c-base:latest:latest
invalid reference format`

The working format is:
`oracle-ee-12c-base:latest`
